### PR TITLE
Fix brand search in FaturaDAO

### DIFF
--- a/src/com/GuardouPagou/dao/FaturaDAO.java
+++ b/src/com/GuardouPagou/dao/FaturaDAO.java
@@ -118,9 +118,11 @@ public class FaturaDAO {
                 + "JOIN notas_fiscais n ON f.nota_fiscal_id = n.id "
                 + "WHERE n.marca ILIKE ?";
 
-        try (Connection conn = DatabaseConnection.getConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
+        try (Connection conn = DatabaseConnection.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
 
-            stmt.setString(1, nomeMarca);
+            // Permitir busca parcial ignorando maiúsculas/minúsculas
+            stmt.setString(1, "%" + nomeMarca + "%");
             ResultSet rs = stmt.executeQuery();
 
             while (rs.next()) {


### PR DESCRIPTION
## Summary
- allow partial brand matches when filtering invoices

## Testing
- `javac @sources.txt` *(fails: package javafx.* does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6844b0f18f5883318b7c4d0e809e97cc