### PR TITLE
Refatora queries para usar marca_id

### DIFF
--- a/src/com/GuardouPagou/dao/FaturaDAO.java
+++ b/src/com/GuardouPagou/dao/FaturaDAO.java
@@ -59,7 +59,7 @@ public class FaturaDAO {
     public ObservableList<Fatura> listarFaturas() throws SQLException {
         ObservableList<Fatura> faturas = FXCollections.observableArrayList();
         String sql = "SELECT f.id, f.nota_fiscal_id, n.numero_nota, f.numero_fatura, f.vencimento, f.valor, f.status, "
-                + "COALESCE(m.nome, n.marca) AS marca "
+                + "m.nome AS marca "
                 + "FROM faturas f "
                 + "JOIN notas_fiscais n ON f.nota_fiscal_id = n.id "
                 + "LEFT JOIN marcas m ON n.marca_id = m.id "
@@ -116,7 +116,8 @@ public class FaturaDAO {
         String sql = "SELECT f.id, f.nota_fiscal_id, n.numero_nota, f.numero_fatura, f.vencimento, f.valor, f.status "
                 + "FROM faturas f "
                 + "JOIN notas_fiscais n ON f.nota_fiscal_id = n.id "
-                + "WHERE n.marca ILIKE ?";
+                + "JOIN marcas m ON n.marca_id = m.id "
+                + "WHERE m.nome ILIKE ?";
 
         try (Connection conn = DatabaseConnection.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
@@ -143,7 +144,7 @@ public class FaturaDAO {
         ObservableList<Fatura> faturas = FXCollections.observableArrayList();
         StringBuilder sqlBuilder = new StringBuilder(
                 "SELECT f.id, f.nota_fiscal_id, n.numero_nota, f.numero_fatura, f.vencimento, f.valor, f.status, "
-                + "COALESCE(m.nome, n.marca) AS marca, n.arquivada "
+                + "m.nome AS marca, n.arquivada "
                 + "FROM faturas f "
                 + "JOIN notas_fiscais n ON f.nota_fiscal_id = n.id "
                 + "LEFT JOIN marcas m ON n.marca_id = m.id "

--- a/src/com/GuardouPagou/dao/MarcaDAO.java
+++ b/src/com/GuardouPagou/dao/MarcaDAO.java
@@ -63,7 +63,7 @@ public class MarcaDAO {
         return marcas;
     }
     
-        public int getNextId() throws SQLException {
+    public int getNextId() throws SQLException {
         String sql = "SELECT COALESCE(MAX(id), 0) + 1 AS next_id FROM marcas";
         try (Connection conn = DatabaseConnection.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);
@@ -73,5 +73,19 @@ public class MarcaDAO {
             }
             return 1;
         }
+    }
+
+    public Integer obterIdPorNome(String nome) throws SQLException {
+        String sql = "SELECT id FROM marcas WHERE nome = ?";
+        try (Connection conn = DatabaseConnection.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, nome);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt("id");
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- remove referêncas obsoletas a `notas_fiscais.marca`
- faz JOIN com `marcas` utilizando `marca_id`
- atualiza inserção de nota fiscal com o id da marca
- adiciona método utilitário em `MarcaDAO` para buscar id por nome

## Testing
- `ant` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c79a6db08331b59c4812d96e784b