### PR TITLE
Remove CSS duplication in views

### DIFF
--- a/src/com/GuardouPagou/views/ArquivadasView.java
+++ b/src/com/GuardouPagou/views/ArquivadasView.java
@@ -90,10 +90,8 @@ public class ArquivadasView {
         // Tabela de notas arquivadas
         tabelaNotasArquivadas = new TableView<>();
         tabelaNotasArquivadas.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
-        tabelaNotasArquivadas.getStylesheets().add(
-                getClass().getResource("/css/styles.css").toExternalForm()
-        );
 
+        ViewUtils.aplicarEstiloPadrao(tabelaNotasArquivadas);
         // Coluna Número da Nota
         TableColumn<NotaFiscalArquivadaDAO, String> colNumeroNota =
                 new TableColumn<>("Número Nota Fiscal");

--- a/src/com/GuardouPagou/views/MainView.java
+++ b/src/com/GuardouPagou/views/MainView.java
@@ -116,7 +116,6 @@ public class MainView {
     private void criarUI() {
         root = new BorderPane();
         root.getStyleClass().add("main-root");
-        root.getStylesheets().add(getClass().getResource("/css/styles.css").toExternalForm());
 
         VBox menuLateral = new VBox();
         menuLateral.getStyleClass().add("menu-lateral-root");

--- a/src/com/GuardouPagou/views/MarcaView.java
+++ b/src/com/GuardouPagou/views/MarcaView.java
@@ -1,6 +1,5 @@
 package com.GuardouPagou.views;
 
-import java.net.URL;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.*;
@@ -29,11 +28,6 @@ public class MarcaView {
         // Raiz e CSS
         root = new BorderPane();
         root.setStyle("-fx-background-color: #323437; -fx-padding: 20;");
-        URL cssUrl = MarcaView.class.getResource("/css/styles.css");
-        if (cssUrl == null) {
-            throw new IllegalStateException("styles.css não encontrado em /css");
-        }
-        root.getStylesheets().add(cssUrl.toExternalForm());
 
         // ——— HEADER ———
         lblTitulo = new Label("Cadastro de Marcas");

--- a/src/com/GuardouPagou/views/NotaFaturaView.java
+++ b/src/com/GuardouPagou/views/NotaFaturaView.java
@@ -43,7 +43,6 @@ public class NotaFaturaView {
     private void criarUI() {
         // Carrega o CSS de estilos e aplica classe de root
         root.getStyleClass().add("nota-fatura-root");
-        root.getStylesheets().add(getClass().getResource("/css/styles.css").toExternalForm());
         root.setStyle("-fx-background-color: #323437; -fx-padding: 20;");
 
         // ——— HEADER ———


### PR DESCRIPTION
## Summary
- centralize stylesheet loading in Main
- clean up views that added stylesheets directly
- apply default table style in `ArquivadasView`

## Testing
- `javac $(find src -name '*.java')` *(fails: package javafx.* not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f30acfbd483319fb18c80d1f0ed29