### PR TITLE
Resolve warnings in ArquivadasView

### DIFF
--- a/src/com/GuardouPagou/views/ArquivadasView.java
+++ b/src/com/GuardouPagou/views/ArquivadasView.java
@@ -13,6 +13,8 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import java.sql.SQLException;
 import java.time.LocalDate;
@@ -20,6 +22,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 public class ArquivadasView {
+
+    private static final Logger LOGGER = Logger.getLogger(ArquivadasView.class.getName());
 
     private BorderPane root;
     private TableView<NotaFiscalArquivadaDAO> tabelaNotasArquivadas;
@@ -89,7 +93,7 @@ public class ArquivadasView {
 
         // Tabela de notas arquivadas
         tabelaNotasArquivadas = new TableView<>();
-        tabelaNotasArquivadas.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        tabelaNotasArquivadas.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_FLEX_LAST_COLUMN);
 
         ViewUtils.aplicarEstiloPadrao(tabelaNotasArquivadas);
         // Coluna Número da Nota
@@ -105,32 +109,7 @@ public class ArquivadasView {
         colQtdFaturas.setPrefWidth(100);
 
         // Coluna Marca com cor dinâmica
-        TableColumn<NotaFiscalArquivadaDAO, String> colMarca =
-                new TableColumn<>("Marca");
-        colMarca.setCellValueFactory(new PropertyValueFactory<>("marca"));
-        colMarca.setPrefWidth(150);
-        colMarca.setCellFactory(col -> new TableCell<>() {
-            @Override
-            protected void updateItem(String marca, boolean empty) {
-                super.updateItem(marca, empty);
-                if (empty || marca == null) {
-                    setText(null);
-                    setStyle("");
-                } else {
-                    setText(marca);
-                    String cor = getTableView()
-                            .getItems()
-                            .get(getIndex())
-                            .getMarcaColor();
-                    setTextFill(Color.web(cor));
-                    setStyle(
-                            "-fx-background-color: transparent; " +
-                                    "-fx-font-weight: bold; " +
-                                    "-fx-alignment: CENTER-LEFT;"
-                    );
-                }
-            }
-        });
+        TableColumn<NotaFiscalArquivadaDAO, String> colMarca = criarColunaMarca();
 
         // Coluna Data de Arquivamento
         TableColumn<NotaFiscalArquivadaDAO, LocalDate> colDataArquivamento =
@@ -138,7 +117,7 @@ public class ArquivadasView {
         colDataArquivamento.setCellValueFactory(new PropertyValueFactory<>("dataArquivamento"));
         colDataArquivamento.setPrefWidth(140);
         DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-        colDataArquivamento.setCellFactory(col -> new TableCell<>() {
+        colDataArquivamento.setCellFactory(unused -> new TableCell<>() {
             @Override
             protected void updateItem(LocalDate data, boolean empty) {
                 super.updateItem(data, empty);
@@ -154,13 +133,10 @@ public class ArquivadasView {
                 colDataArquivamento
         );
         try {
-            tabelaNotasArquivadas.setItems(
-                    FXCollections.observableArrayList(
-                            new NotaFiscalDAO().listarNotasFiscaisArquivadasComContagem((Map<String,Object>) null)
-                    )
-            );
+            var notas = new NotaFiscalDAO().listarNotasFiscaisArquivadasComContagem(null);
+            tabelaNotasArquivadas.setItems(FXCollections.observableArrayList(notas));
         } catch (SQLException e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, "Erro ao carregar notas arquivadas", e);
         }
 
         // Monta o layout
@@ -193,5 +169,34 @@ public class ArquivadasView {
     }
     public Button getBtnLimparBusca() {
         return btnLimparBusca;
+    }
+
+    private TableColumn<NotaFiscalArquivadaDAO, String> criarColunaMarca() {
+        TableColumn<NotaFiscalArquivadaDAO, String> colMarca = new TableColumn<>("Marca");
+        colMarca.setCellValueFactory(new PropertyValueFactory<>("marca"));
+        colMarca.setPrefWidth(150);
+        colMarca.setCellFactory(unused -> new TableCell<>() {
+            @Override
+            protected void updateItem(String marca, boolean empty) {
+                super.updateItem(marca, empty);
+                if (empty || marca == null) {
+                    setText(null);
+                    setStyle("");
+                } else {
+                    setText(marca);
+                    String cor = getTableView()
+                            .getItems()
+                            .get(getIndex())
+                            .getMarcaColor();
+                    setTextFill(Color.web(cor));
+                    setStyle(
+                            "-fx-background-color: transparent; " +
+                                    "-fx-font-weight: bold; " +
+                                    "-fx-alignment: CENTER-LEFT;"
+                    );
+                }
+            }
+        });
+        return colMarca;
     }
 }


### PR DESCRIPTION
## Summary
- replace deprecated resize policy
- use a logger instead of `printStackTrace`
- avoid redundant cast and varargs warning
- extract `criarColunaMarca` helper
- silence unused lambda parameters

## Testing
- `ant -noinput -q jar` *(fails: `ant` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861be5b4fb483318ced818aeb40acd9