### PR TITLE
Add alert email management and scheduled notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ CREATE TABLE faturas (
     atualizado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE alerta_emails (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE
+);
+
 UPDATE notas_fiscais n
 SET marca_id = m.id
 FROM marcas m
@@ -151,8 +156,10 @@ manifest.mf
 ## 💡 Observações
 
 * Certifique-se de adicionar o `postgresql-42.7.5.jar` ao **classpath** do projeto no NetBeans ou no seu ambiente Java.
+* Para o envio de e-mails instale `jakarta.mail-2.1.2.jar` e `jakarta.activation-2.1.2.jar` no classpath.
 * Configure corretamente o **usuário, senha e URL** do banco de dados no seu código Java para a conexão funcionar.
 * O arquivo `DataBaseConnection.java` está na raiz do projeto caso não tenha ou foi perdido.
+* Configure as variáveis de ambiente `MAIL_HOST`, `MAIL_USER` e `MAIL_PASS` para as credenciais do servidor SMTP.
 
 ---
 

--- a/src/com/GuardouPagou/controllers/AlertaEmailController.java
+++ b/src/com/GuardouPagou/controllers/AlertaEmailController.java
@@ -1,0 +1,65 @@
+package com.GuardouPagou.controllers;
+
+import com.GuardouPagou.dao.AlertaEmailDAO;
+import com.GuardouPagou.models.AlertaEmail;
+import com.GuardouPagou.views.AlertaEmailView;
+import javafx.scene.control.Alert;
+
+import java.sql.SQLException;
+
+public class AlertaEmailController {
+    private final AlertaEmailView view;
+    private final AlertaEmailDAO dao;
+
+    public AlertaEmailController(AlertaEmailView view) {
+        this.view = view;
+        this.dao = new AlertaEmailDAO();
+        init();
+    }
+
+    private void init() {
+        try {
+            view.getTabela().setItems(dao.listarEmails());
+        } catch (SQLException e) {
+            mostrarErro("Erro ao carregar e-mails: " + e.getMessage());
+        }
+
+        view.getBtnAdicionar().setOnAction(e -> adicionarEmail());
+        view.getBtnRemover().setOnAction(e -> removerEmail());
+    }
+
+    private void adicionarEmail() {
+        String email = view.getTfEmail().getText().trim();
+        if (!validarEmail(email)) {
+            mostrarErro("E-mail inv\u00e1lido");
+            return;
+        }
+        try {
+            dao.inserirEmail(email);
+            view.getTabela().setItems(dao.listarEmails());
+            view.getTfEmail().clear();
+        } catch (SQLException e) {
+            mostrarErro("N\u00e3o foi poss\u00edvel salvar: " + e.getMessage());
+        }
+    }
+
+    private void removerEmail() {
+        AlertaEmail selected = view.getTabela().getSelectionModel().getSelectedItem();
+        if (selected == null) return;
+        try {
+            dao.removerEmail(selected.getId());
+            view.getTabela().getItems().remove(selected);
+        } catch (SQLException e) {
+            mostrarErro("Erro ao remover: " + e.getMessage());
+        }
+    }
+
+    private boolean validarEmail(String email) {
+        return email.matches("^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,}$");
+    }
+
+    private void mostrarErro(String msg) {
+        Alert a = new Alert(Alert.AlertType.ERROR, msg);
+        a.showAndWait();
+    }
+}

--- a/src/com/GuardouPagou/controllers/MainController.java
+++ b/src/com/GuardouPagou/controllers/MainController.java
@@ -164,14 +164,7 @@ public class MainController {
             modal.showAndWait();
         });
 
-        view.getBtnSalvarEmail().setOnAction(e -> {
-            String email = view.getEmailField().getText();
-            if (validarEmail(email)) {
-                atualizarConteudo("E-mail para alertas salvo: " + email);
-            } else {
-                atualizarConteudo("E-mail inválido!");
-            }
-        });
+        view.getBtnSalvarEmail().setOnAction(e -> abrirGerenciadorEmails());
     }
 
     private void atualizarConteudo(String texto) {
@@ -180,6 +173,31 @@ public class MainController {
 
     private boolean validarEmail(String email) {
         return email != null && email.matches("^[\\w.-]+@[\\w.-]+\\.[a-z]{2,}$");
+    }
+
+    private void abrirGerenciadorEmails() {
+        Stage modal = new Stage();
+        Window owner = view.getRoot().getScene().getWindow();
+        modal.initOwner(owner);
+        modal.initModality(Modality.WINDOW_MODAL);
+        modal.setTitle("E-mails de Alerta");
+
+        modal.getIcons().add(new Image(Objects.requireNonNull(getClass().getResourceAsStream("/icons/campaing.png"))));
+
+        AlertaEmailView alertaView = new AlertaEmailView();
+        new AlertaEmailController(alertaView);
+
+        Scene scene = new Scene(alertaView.getRoot(), 450, 350);
+        scene.getStylesheets().addAll(view.getRoot().getScene().getStylesheets());
+        scene.setOnKeyPressed(ev -> {
+            if (ev.getCode() == KeyCode.ESCAPE) {
+                modal.close();
+            }
+        });
+
+        modal.setScene(scene);
+        modal.setResizable(false);
+        modal.showAndWait();
     }
 
     private void abrirDetalhesNotaFiscal(Fatura fatura) {

--- a/src/com/GuardouPagou/dao/AlertaEmailDAO.java
+++ b/src/com/GuardouPagou/dao/AlertaEmailDAO.java
@@ -1,0 +1,45 @@
+package com.GuardouPagou.dao;
+
+import com.GuardouPagou.models.AlertaEmail;
+import com.GuardouPagou.models.DatabaseConnection;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import java.sql.*;
+
+public class AlertaEmailDAO {
+
+    public ObservableList<AlertaEmail> listarEmails() throws SQLException {
+        ObservableList<AlertaEmail> emails = FXCollections.observableArrayList();
+        String sql = "SELECT id, email FROM alerta_emails ORDER BY email";
+        try (Connection conn = DatabaseConnection.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                AlertaEmail a = new AlertaEmail();
+                a.setId(rs.getInt("id"));
+                a.setEmail(rs.getString("email"));
+                emails.add(a);
+            }
+        }
+        return emails;
+    }
+
+    public void inserirEmail(String email) throws SQLException {
+        String sql = "INSERT INTO alerta_emails(email) VALUES (?) ON CONFLICT DO NOTHING";
+        try (Connection conn = DatabaseConnection.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, email);
+            stmt.executeUpdate();
+        }
+    }
+
+    public void removerEmail(int id) throws SQLException {
+        String sql = "DELETE FROM alerta_emails WHERE id = ?";
+        try (Connection conn = DatabaseConnection.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, id);
+            stmt.executeUpdate();
+        }
+    }
+}

--- a/src/com/GuardouPagou/dao/FaturaDAO.java
+++ b/src/com/GuardouPagou/dao/FaturaDAO.java
@@ -269,4 +269,29 @@ public class FaturaDAO {
         }
         return faturas;
     }
+
+    public List<Fatura> buscarFaturasPendentesAte(LocalDate dataLimite) throws SQLException {
+        List<Fatura> faturas = new ArrayList<>();
+        String sql = "SELECT f.id, f.nota_fiscal_id, n.numero_nota, m.nome AS marca, f.vencimento, f.valor " +
+                "FROM faturas f JOIN notas_fiscais n ON f.nota_fiscal_id = n.id " +
+                "LEFT JOIN marcas m ON n.marca_id = m.id " +
+                "WHERE f.status = 'Pendente' AND f.vencimento BETWEEN CURRENT_DATE AND ?";
+        try (Connection conn = DatabaseConnection.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setDate(1, Date.valueOf(dataLimite));
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    Fatura f = new Fatura();
+                    f.setId(rs.getInt("id"));
+                    f.setNotaFiscalId(rs.getInt("nota_fiscal_id"));
+                    f.setNumeroNota(rs.getString("numero_nota"));
+                    f.setMarca(rs.getString("marca"));
+                    f.setVencimento(rs.getDate("vencimento").toLocalDate());
+                    f.setValor(rs.getDouble("valor"));
+                    faturas.add(f);
+                }
+            }
+        }
+        return faturas;
+    }
 }

--- a/src/com/GuardouPagou/models/AlertaEmail.java
+++ b/src/com/GuardouPagou/models/AlertaEmail.java
@@ -1,0 +1,22 @@
+package com.GuardouPagou.models;
+
+public class AlertaEmail {
+    private int id;
+    private String email;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/com/GuardouPagou/models/Main.java
+++ b/src/com/GuardouPagou/models/Main.java
@@ -2,6 +2,7 @@ package com.GuardouPagou.models;
 
 import com.GuardouPagou.views.MainView;
 import com.GuardouPagou.controllers.MainController;
+import com.GuardouPagou.services.AlertaService;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
@@ -11,6 +12,7 @@ import javafx.stage.Stage;
 import java.util.Objects;
 
 public class Main extends Application {
+    private AlertaService alertaService;
     @Override
     public void start(Stage primaryStage) {
         // 🅰️ Carregando a fonte Poppins antes de qualquer tela
@@ -36,6 +38,9 @@ public class Main extends Application {
         MainView mainView = new MainView();
         new MainController(mainView);
 
+        alertaService = new AlertaService();
+        alertaService.iniciar();
+
         Scene scene = new Scene(mainView.getRoot(), 950, 700);
 
         scene.getStylesheets().add(
@@ -55,6 +60,13 @@ public class Main extends Application {
         primaryStage.setMaximized(true);
         primaryStage.setScene(scene);
         primaryStage.show();
+    }
+
+    @Override
+    public void stop() {
+        if (alertaService != null) {
+            alertaService.parar();
+        }
     }
 
     public static void main(String[] args) {

--- a/src/com/GuardouPagou/services/AlertaService.java
+++ b/src/com/GuardouPagou/services/AlertaService.java
@@ -1,0 +1,40 @@
+package com.GuardouPagou.services;
+
+import com.GuardouPagou.dao.AlertaEmailDAO;
+import com.GuardouPagou.dao.FaturaDAO;
+import com.GuardouPagou.models.AlertaEmail;
+import com.GuardouPagou.models.Fatura;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class AlertaService {
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private final AlertaEmailDAO emailDAO = new AlertaEmailDAO();
+    private final FaturaDAO faturaDAO = new FaturaDAO();
+
+    public void iniciar() {
+        scheduler.scheduleAtFixedRate(this::verificarEEnviar, 0, 1, TimeUnit.DAYS);
+    }
+
+    public void parar() {
+        scheduler.shutdownNow();
+    }
+
+    private void verificarEEnviar() {
+        LocalDate limite = LocalDate.now().plusDays(3);
+        try {
+            List<Fatura> faturas = faturaDAO.buscarFaturasPendentesAte(limite);
+            if (faturas.isEmpty()) return;
+            List<AlertaEmail> emails = emailDAO.listarEmails();
+            for (AlertaEmail dest : emails) {
+                EmailSender.enviarAlerta(dest.getEmail(), faturas);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/com/GuardouPagou/services/EmailSender.java
+++ b/src/com/GuardouPagou/services/EmailSender.java
@@ -1,0 +1,46 @@
+package com.GuardouPagou.services;
+
+import com.GuardouPagou.models.Fatura;
+import jakarta.mail.*;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import java.util.List;
+import java.util.Properties;
+
+public class EmailSender {
+    private static final String USER = System.getenv("MAIL_USER");
+    private static final String PASS = System.getenv("MAIL_PASS");
+    private static final String HOST = System.getenv("MAIL_HOST");
+
+    public static void enviarAlerta(String destinatario, List<Fatura> faturas) throws MessagingException {
+        if (USER == null || PASS == null || HOST == null) return;
+
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.host", HOST);
+        props.put("mail.smtp.port", "587");
+
+        Session session = Session.getInstance(props, new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return new PasswordAuthentication(USER, PASS);
+            }
+        });
+
+        Message message = new MimeMessage(session);
+        message.setFrom(new InternetAddress(USER));
+        message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(destinatario));
+        message.setSubject("[ALERTA] Fatura prestes a vencer");
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("Faturas vencendo nos próximos dias:\n\n");
+        for (Fatura f : faturas) {
+            sb.append(String.format("NF: %s | Marca: %s | Venc: %s | Valor: R$ %.2f\n",
+                    f.getNumeroNota(), f.getMarca(), f.getVencimento(), f.getValor()));
+        }
+        message.setText(sb.toString());
+
+        Transport.send(message);
+    }
+}

--- a/src/com/GuardouPagou/views/AlertaEmailView.java
+++ b/src/com/GuardouPagou/views/AlertaEmailView.java
@@ -1,0 +1,61 @@
+package com.GuardouPagou.views;
+
+import com.GuardouPagou.models.AlertaEmail;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.*;
+import javafx.scene.layout.*;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontWeight;
+import javafx.scene.control.cell.PropertyValueFactory;
+
+public class AlertaEmailView {
+    private final BorderPane root;
+    private final TableView<AlertaEmail> tabela;
+    private final TextField tfEmail;
+    private final Button btnAdicionar;
+    private final Button btnRemover;
+
+    public AlertaEmailView() {
+        root = new BorderPane();
+        tabela = new TableView<>();
+        tfEmail = new TextField();
+        btnAdicionar = new Button("Adicionar");
+        btnRemover = new Button("Remover Selecionado");
+        criarUI();
+    }
+
+    private void criarUI() {
+        root.setStyle("-fx-background-color: #323437; -fx-padding: 20;");
+
+        Label titulo = new Label("Destinatários de Alertas");
+        titulo.setFont(Font.font("Poppins", FontWeight.BOLD, 20));
+        titulo.setTextFill(Color.web("#F0A818"));
+        VBox header = new VBox(5, titulo, new Separator());
+        header.setAlignment(Pos.CENTER_LEFT);
+
+        tabela.getStyleClass().add("table-padrao");
+        TableColumn<AlertaEmail, String> colEmail = new TableColumn<>("E-mail");
+        colEmail.setCellValueFactory(new PropertyValueFactory<>("email"));
+        colEmail.setPrefWidth(300);
+        tabela.getColumns().add(colEmail);
+
+        tfEmail.setPromptText("email@exemplo.com");
+        btnAdicionar.getStyleClass().add("modal-button");
+        btnRemover.getStyleClass().add("modal-button");
+        HBox controls = new HBox(10, tfEmail, btnAdicionar, btnRemover);
+        controls.setAlignment(Pos.CENTER);
+        controls.setPadding(new Insets(10, 0, 0, 0));
+
+        root.setTop(header);
+        root.setCenter(tabela);
+        root.setBottom(controls);
+    }
+
+    public BorderPane getRoot() { return root; }
+    public TableView<AlertaEmail> getTabela() { return tabela; }
+    public TextField getTfEmail() { return tfEmail; }
+    public Button getBtnAdicionar() { return btnAdicionar; }
+    public Button getBtnRemover() { return btnRemover; }
+}


### PR DESCRIPTION
## Summary
- handle alert email recipients in a new modal window
- persist alert emails with `AlertaEmailDAO`
- schedule daily alert service with `AlertaService`
- send e-mail messages using `EmailSender` (Jakarta Mail)
- start/stop the service from `Main`
- document new `alerta_emails` table and dependencies

## Testing
- `javac -d /tmp/build $(find src -name '*.java')` *(fails: package javafx.collections does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6866c0d28cc88331ac2b77ec7d5fc45f